### PR TITLE
fixed alert and notice messages

### DIFF
--- a/app/assets/stylesheets/components/_userpage.scss
+++ b/app/assets/stylesheets/components/_userpage.scss
@@ -18,10 +18,6 @@
   padding-right: 15px;
 }
 
-.alert {
-  background-color: $lightgrey;
-}
-
 .user-td {
   height: 50px;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,8 +13,6 @@
     <%= render 'shared/flashes' %>
     <% unless action_name == "home" %>
       <%= render 'shared/navbar'  %>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
     <% end %>
     <div class="main">
       <%= yield %>


### PR DESCRIPTION
The alert and notice messages from the devise gem were causing some whitespace conflicts which have now been resolved - the messages will still display on login.