### PR TITLE
rearranged ordering of leads, grouped buttons together

### DIFF
--- a/app/views/leads/index.html.erb
+++ b/app/views/leads/index.html.erb
@@ -28,21 +28,23 @@
             <th class="user-th">Contact Name:</th>
             <th class="user-th">Contact Email:</th>
             <th class="user-th">Lead Source</th>
+            <th class="user-th">Lead Status</th>
+            <th class="user-th">Action</th>
           </tr>
 
           <% @leads.each do |lead| %>
           <tr class="user-tr">
-            <td class="user-td"><%= lead.status.capitalize %></td>
             <td class="user-td"><%= link_to lead.user.name, user_path(lead.user) %></td>
-            <td class="user-td"><%= lead.name %></td>
             <td class="user-td"><%= lead.created_at %></td>
+            <td class="user-td"><%= lead.name %></td>
             <td class="user-td"><%= lead.email %></td>
             <td class="user-td"><%= lead.source %></td>
-            <td class="user-td"><%= link_to "Accept Lead", mark_as_accepted_lead_path(lead), method: :patch, class: "btn btn-primary" %></td>
-            <td class="user-td"><%= link_to "Settle Lead", mark_as_settled_lead_path(lead), method: :patch, class: "btn btn-primary" %></td>
-            <td class="user-td"><%= link_to "Mark as Lost", mark_as_lost_lead_path(lead), method: :patch, class: "btn btn-primary" %></td>
-            <td class="user-td"><%= link_to "Edit", edit_lead_path(lead), class: "btn btn-primary" %></td>
-            <td class="user-td"><%= link_to "Delete", lead_path(lead), method: :delete, data: { confirm: "Are you sure you want to Delete this lead?" } %></td>
+            <td class="user-td"><%= lead.status.capitalize %></td>
+            <td class="user-td"><%= link_to "Accept Lead", mark_as_accepted_lead_path(lead), method: :patch, class: "btn btn-primary" %>
+            <%= link_to "Settle Lead", mark_as_settled_lead_path(lead), method: :patch, class: "btn btn-primary" %>
+            <%= link_to "Mark as Lost", mark_as_lost_lead_path(lead), method: :patch, class: "btn btn-primary" %>
+            <%= link_to "Edit", edit_lead_path(lead), class: "btn btn-primary" %>
+            <%= link_to "Delete", lead_path(lead), method: :delete, data: { confirm: "Are you sure you want to Delete this lead?" } %></td>
           </tr>
           <% end %>
           </table>


### PR DESCRIPTION
The leads table had the information misaligned with the headers (Salesperson => "Accept/Edit" etc). Re-ordered everything so that 