### PR TITLE
removed rogue login button from navbar

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -43,12 +43,6 @@
           </ul>
         </div>
       </div>
-
-    <% else %>
-
-      <!-- Login text link -->
-      <%= link_to t(".sign_in", default: "Login"), new_user_session_path, class: "navbar-wagon-item navbar-wagon-link" %>
-
     <% end %>
 
     <!-- Button (call-to-action) -->

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,11 +22,11 @@ ActiveRecord::Schema.define(version: 20170425075642) do
     t.datetime "accepted_at"
     t.string   "status"
     t.string   "source"
+    t.string   "phone"
     t.float    "response_time"
     t.integer  "user_id"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
-    t.string   "phone"
     t.text     "html"
     t.index ["user_id"], name: "index_leads_on_user_id", using: :btree
   end


### PR DESCRIPTION
There was a leftover "login" button on the navbar from a previous layout idea - it was redundant so I went ahead and took it out.