### PR TITLE
updated meta tags to follow the capitalization decisions

### DIFF
--- a/config/meta.yml
+++ b/config/meta.yml
@@ -1,5 +1,5 @@
-meta_product_name: "Leadmailer"
-meta_title: "Leadmailer: Route, Record, Report"
+meta_product_name: "LeadMailer"
+meta_title: "LeadMailer: Route, Record, Report"
 meta_description: "The Lead Distribution Solution for Sales Teams"
 meta_url: "www.leadmailer.pro"
 meta_image: "homelogo1200-630.png"


### PR DESCRIPTION
Meta tags needed changing since "Leadmailer" will now be stylistically written as "LeadMailer" for the brand.