### PR TITLE
set widths on user page

### DIFF
--- a/app/assets/stylesheets/components/_switch2.scss
+++ b/app/assets/stylesheets/components/_switch2.scss
@@ -9,7 +9,7 @@
 
 .slider2 {
   height: 26px;
-  width: 100px;
+  width: 88px;
   position: absolute;
   cursor: pointer;
   top: 0;
@@ -64,9 +64,9 @@ input:focus + .slider2 {
 }
 
 input:checked + .slider2:before {
-  -webkit-transform: translateX(72px);
-  -ms-transform: translateX(72px);
-  transform: translateX(72px);
+  -webkit-transform: translateX(60px);
+  -ms-transform: translateX(60px);
+  transform: translateX(60px);
 }
 
 /* Rounded sliders */
@@ -81,15 +81,15 @@ input:checked + .slider2:before {
 .ontext2 {
   margin-right: 30px;
   position: absolute;
-  left: 10px;
-  top: 5.5px;
+  left: 6px;
+  top: 7px;
   text-align: left;
-  font-size: 10px;
+  font-size: 9px;
 }
 
 .offtext2 {
   position: absolute;
-  right: 11px;
-  top: 5.5px;
-  font-size: 10px;
+  right: 7px;
+  top: 7px;
+  font-size: 9px;
 }

--- a/app/assets/stylesheets/components/_userpage.scss
+++ b/app/assets/stylesheets/components/_userpage.scss
@@ -31,7 +31,7 @@
 }
 
 .fa-times {
-  padding-right: 10px;
+  padding-right: 0px;
   margin-left: -6px;
   color: #E81617;
 }
@@ -286,3 +286,26 @@
   }
 }
 
+.delete-width {
+  width: 80px;
+}
+
+.name-width {
+  width: 130px;
+}
+
+.conversion-width {
+  width: 110px;
+}
+
+.response-width {
+  width: 170px;
+}
+
+.avail-width {
+  width: 100px;
+}
+
+.email-width {
+  width: 200px;
+}

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -68,14 +68,14 @@
                   <tr class="bg-grey light-font" id="table-header-green">
                     <th class="user-th rank-width"> <%= link_to users_path(order: "rank") do %>Rank<i class="fa fa-sort light-font" aria-hidden="true"></i><% end %></th>
 
-                    <th class="user-th"><%= link_to users_path(order: "name") do %>Salesperson<i class="fa fa-sort light-font" aria-hidden="true"></i><% end %></th>
+                    <th class="user-th name-width"><%= link_to users_path(order: "name") do %>Salesperson<i class="fa fa-sort light-font" aria-hidden="true"></i><% end %></th>
 
-                    <th class="user-th"><%= link_to users_path(order: "email") do %>Email<i class="fa fa-sort light-font" aria-hidden="true"></i><% end %></th>
+                    <th class="user-th email-width"><%= link_to users_path(order: "email") do %>Email<i class="fa fa-sort light-font" aria-hidden="true"></i><% end %></th>
 
-                    <th class="user-th">Conversion Rate</th>
-                    <th class="user-th">Avg Response Time</th>
+                    <th class="user-th conversion-width">Conversion %</th>
+                    <th class="user-th response-width">Avg Response Time</th>
                     <th class="user-th avail-width">Availability</th>
-                    <th class="user-th">Delete User</th>
+                    <th class="user-th delete-width">Delete</th>
                   </tr>
 
                   <% @users.each do |user| %>


### PR DESCRIPTION
Widths adjusted on the staff overview page to prevent line breaks occurring in names and email addresses.