### PR TITLE
fixed pending leads conditional

### DIFF
--- a/app/assets/stylesheets/components/_showpage.scss
+++ b/app/assets/stylesheets/components/_showpage.scss
@@ -6,3 +6,13 @@
   padding-left: 14px;
   vertical-align: middle;
 }
+
+.no-pending-details {
+  margin-top: 15px;
+  height: 50px;
+  font-size: 13px;
+  text-align: left;
+  padding-left: 14px;
+  vertical-align: middle;
+  margin-bottom: -40px;
+}

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -61,6 +61,7 @@
           <th class="user-th">Status:</th>
           <th class="user-th">Received:</th>
         </tr>
+        <% if @pending_leads.any? %>
         <% @pending_leads.each do |lead| %>
         <tr class="user-tr">
           <td class="user-td"><%= link_to "Accept", mark_as_accepted_lead_path(lead), method: :patch, class: "btn btn-primary table-button" %></td>
@@ -70,6 +71,10 @@
         </tr>
         <% end %>
         </table>
+        <% else %>
+          </table>
+          <div class="no-pending-details">No pending leads to display</div>
+        <% end %>
       </div><BR><BR>
 
  <!-- WIP LEADS TABLE -->


### PR DESCRIPTION
The "pending leads" now also displays a message when zero leads exist for the user - this brings consistency with the 2 tables below it ("ongoing leads" and "lead history") to improve visual clarity.